### PR TITLE
Removed letter-spacing in bulbed posts

### DIFF
--- a/Themes/Giggle/sass/ballpit.scss
+++ b/Themes/Giggle/sass/ballpit.scss
@@ -4496,7 +4496,7 @@ span.hidelink
 }
 .superbulbedpost {
   .post {
-    .inner { padding-top:2.5em; padding-bottom: 2.5em; line-height: 1.85em; letter-spacing: 0.2em; }
+    .inner { padding-top:2.5em; padding-bottom: 2.5em; line-height: 1.85em; }
   }
 }
 


### PR DESCRIPTION
The spacing was too wide, and made the text harder to read.