### PR TITLE
Removes all attributes from twitter URLs while embedding to not break it

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1601,6 +1601,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 				var oHolder = $(this);
 				var sStr = $(this).attr(\'href\');
 				sStr = sStr.replace(/\/+$/, "");
+				sStr = sStr.replace(/\?.+/, "");
 				sStr = sStr.substr(sStr.lastIndexOf(\'/\') + 1);
 				$.getJSON("' . $boardurl .'/tweet-cache.php?id=" + sStr, function(data) {
 					oHolder.before(data.html);


### PR DESCRIPTION
This should take care of #41 and any other future parameter stupidities.